### PR TITLE
Fix missing key in FooterColumn links

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,7 +14,7 @@ const Footer = () => {
 
           <div className='flex flex-wrap gap-10 sm:justify-between md:flex-1'>
             {FOOTER_LINKS.map((columns) => (
-              <FooterColumn title={columns.title}>
+              <FooterColumn title={columns.title} key={columns.title}>
                 <ul className="regular-14 flex flex-col gap-4 text-gray-30">
                   {columns.links.map((link) => (
                     <Link href="/" key={link}>


### PR DESCRIPTION
- Added the missing `key` prop to each `Link` component inside the `FooterColumn` to prevent React warnings.
- This ensures proper rendering and avoids potential performance issues.
