### PR TITLE
Fix typo in lg:mg-20 class, changed to lg:mt-20

### DIFF
--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -27,7 +27,7 @@ const Features = () => {
             />
             <h2 className="bold-40 lg:bold-64">Our Features</h2>
           </div>
-          <ul className="mt-10 grid gap-10 md:grid-cols-2 lg:mg-20 lg:gap-20">
+          <ul className="mt-10 grid gap-10 md:grid-cols-2 lg:mt-20 lg:gap-20">
             {FEATURES.map((feature) => (
               <FeatureItem 
                 key={feature.title}


### PR DESCRIPTION
- Corrected a typo in the `ul` class from `lg:mg-20` to `lg:mt-20` for proper margin-top spacing.
